### PR TITLE
typo in continuous

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "verify": "./gradlew check",
     "verify:pact": "./gradlew pactVerify",
     "clean": "./gradlew clean",
-    "tdd": "./gradlew test --conntinuous",
+    "tdd": "./gradlew test --continuous",
     "test": "./gradlew test",
     "test:pact": "npm test && ./pact-validate-provider.sh ./build/pacts",
     "publish:pact": "./gradlew pactPublish",


### PR DESCRIPTION
when you type `rpm run tdd`,  it would trigger `./gradlew test --con*n*tinuous` which is invalid because of the typo. 

Change to continuous.